### PR TITLE
Add contract to language-header->locale.

### DIFF
--- a/koyo-lib/koyo/l10n.rkt
+++ b/koyo-lib/koyo/l10n.rkt
@@ -92,7 +92,8 @@
   (cons (string->symbol (string-downcase language))
         (string->symbol (string-downcase (or country language)))))
 
-(define (language-header->locale header)
+(define/contract (language-header->locale header)
+  (-> string? (or/c false/c string?))
   (define specs
     (for/list ([spec (string-split header ",")])
       (match-define (list _ language country weight)


### PR DESCRIPTION
Everything in `i10n.rkt` is defined by `define/contract` except `language-header->locale`. Does this contract look OK?