### PR TITLE
Support 'de for `localize-date`.

### DIFF
--- a/koyo-lib/koyo/l10n.rkt
+++ b/koyo-lib/koyo/l10n.rkt
@@ -51,6 +51,7 @@
   (-> date-provider? string?)
   (match (current-language)
     ['ro (~t d "dd MMMM, yyyy")]
+    ['de (~t d "dd.MM.yyyy")]
     [_   (~t d "MMMM dd, yyyy")]))
 
 

--- a/koyo-test/koyo/l10n.rkt
+++ b/koyo-test/koyo/l10n.rkt
@@ -1,7 +1,9 @@
 #lang racket/base
 
 (require koyo/l10n
-         rackunit)
+         rackunit
+         srfi/29
+         gregor)
 
 (provide
  l10n-tests)
@@ -20,7 +22,20 @@
       (check-equal? (language-header->locale "en") #f)
       (check-equal? (language-header->locale "en-US") '(en . us))
       (check-equal? (language-header->locale "en, en-US;q=0.5, ro-RO;q=1") '(ro . ro))
-      (check-equal? (language-header->locale "ro, en-GB;q=0.3, en-US;q=0.1, ro-RO;q=0.5") '(ro . ro))))))
+      (check-equal? (language-header->locale "ro, en-GB;q=0.3, en-US;q=0.1, ro-RO;q=0.5") '(ro . ro))))
+
+   (test-suite
+    "localize-date"
+    (let ([d (date 1996 2 15)])
+      (parameterize ([current-language 'ro])
+        (check-equal? (localize-date d)
+                      "15 February, 1996"))
+      (parameterize ([current-language 'de])
+        (check-equal? (localize-date d)
+                      "15.02.1996"))
+      (parameterize ([current-language 'nonsense])
+        (check-equal? (localize-date d)
+                      "February 15, 1996"))))))
 
 (module+ test
   (require rackunit/text-ui)


### PR DESCRIPTION
Additionally, add a few unit tests for `localize-date`.