### PR TITLE
cli: friendlier error messages for `new`

### DIFF
--- a/koyo-lib/koyo/cli.rkt
+++ b/koyo-lib/koyo/cli.rkt
@@ -153,9 +153,11 @@
                                (set! blueprint name)
                                (exit-with-errors! @~a{error: no blueprint named '@name'}))]
      #:args (name)
-     (when (or (directory-exists? name)
-               (file-exists? name))
-       (exit-with-errors! @~a{error: a file called '@name' already exists in the current directory}))
+     (cond
+       [(string=? name ".")
+        (exit-with-errors! @~a{error: "." cannot be used as project name})]
+       [(or (directory-exists? name) (file-exists? name))
+        (exit-with-errors! @~a{error: a file called '@name' already exists in the current directory})])
 
      name))
 


### PR DESCRIPTION
When creating a new project, trying to use `.` produces a slightly confusing error message:

```
error: a file called '.' already exists in the current directory
```

I thought it might be nice to make it more obvious to users that they cannot use the current directory as project root.