### PR TITLE
runner: use `simplify-path` to figure out project root

### DIFF
--- a/koyo-lib/koyo/runner.rkt
+++ b/koyo-lib/koyo/runner.rkt
@@ -55,7 +55,7 @@
   (file-stream-buffer-mode (current-output-port) 'line)
   (file-stream-buffer-mode (current-error-port) 'line)
 
-  (define root-path (normalize-path (build-path dynamic-module-path 'up 'up)))
+  (define root-path (simplify-path (build-path dynamic-module-path 'up 'up)))
   (define command-args
     (if errortrace?
         (list "-l" "errortrace" "-t" dynamic-module-path)


### PR DESCRIPTION
Recent runner updates changed the function used to create the
project's root path - where previously it was
[simplify-path](https://github.com/Bogdanp/koyo/commit/a61266252a9c5447454c1bae7ab13eca8dbec842#diff-7c4be18bc7b4ac6f77c658c275b5cc30L121),
it's currently
[normalize-path](https://github.com/Bogdanp/koyo/commit/a61266252a9c5447454c1bae7ab13eca8dbec842#diff-7c4be18bc7b4ac6f77c658c275b5cc30R61).

At least on my machine, this results in:
```
~/S/t/tc (master)> raco koyo serve
normalize-path: element within the input path is not a directory or does not exist
  element: /Users/sorin/Sandbox/tc/tc/dynamic.rkt
  context...:
   /Applications/Racket v7.7/collects/racket/path.rkt:68:14: normalize
   /Users/sorin/Playground/racket/koyo/koyo-lib/koyo/runner.rkt:48:0: run-forever
   "/Users/sorin/Playground/racket/koyo/koyo-lib/koyo/cli.rkt": [running body]
   temp35_0
   for-loop
   run-module-instance!
   "/Applications/Racket v7.7/collects/raco/raco.rkt": [running body]
   temp35_0
   for-loop
   run-module-instance!
   "/Applications/Racket v7.7/collects/raco/main.rkt": [running body]
   temp35_0
   for-loop
   run-module-instance!
   perform-require!
```