### PR TITLE
dispatch: properly call `next-dispatcher` if no rule matches

### DIFF
--- a/koyo-doc/scribblings/dispatch.scrbl
+++ b/koyo-doc/scribblings/dispatch.scrbl
@@ -38,11 +38,11 @@ function.
    [(else-fun (-> request? response?))
     (dispatch-fun (-> request? any/c ... response?))]]{
 
-  Like @racket[dispatch-roles] but each @racket[dispatch-clause] takes
+  Like @racket[dispatch-rules] but each @racket[dispatch-clause] takes
   an optional list of roles and an optional name.
 
   Returns three values: the first being a dispatcher function like in
-  @racket[dispatch-roles], the second a function that can generate
+  @racket[dispatch-rules], the second a function that can generate
   reverse URIs and the third a function that, given a
   @racket[request], can return the required set of roles for the
   matching @racket[dispatch-fun].

--- a/koyo-lib/blueprints/minimal/app-name-here/components/app.rkt
+++ b/koyo-lib/blueprints/minimal/app-name-here/components/app.rkt
@@ -28,8 +28,7 @@
   (-> session-manager? app?)
   (define-values (dispatch reverse-uri _req-roles)
     (dispatch-rules+roles
-     [("") home-page]
-     [else not-found-page]))
+     [("") home-page]))
 
   ;; Requests go up (starting from the last wrapper) and respones go down!
   (define (stack handler)

--- a/koyo-lib/blueprints/standard/app-name-here/components/app.rkt
+++ b/koyo-lib/blueprints/standard/app-name-here/components/app.rkt
@@ -76,9 +76,7 @@
       (signup-page auth mailer users)]
 
      [("verify" (integer-arg) (string-arg))
-      (verify-page flashes users)]
-
-     [else not-found-page]))
+      (verify-page flashes users)]))
 
   ;; Requests go up (starting from the last wrapper) and respones go down!
   (define (stack handler)

--- a/koyo-lib/koyo/dispatch.rkt
+++ b/koyo-lib/koyo/dispatch.rkt
@@ -58,4 +58,4 @@
      (syntax/loc stx
        (dispatch-rules+roles
         [pat #:method method #:roles (role ...) #:name name fun] ...
-        [else next-dispatcher]))]))
+        [else (lambda (req) (next-dispatcher))]))]))

--- a/koyo-test/koyo/dispatch.rkt
+++ b/koyo-test/koyo/dispatch.rkt
@@ -4,7 +4,8 @@
          koyo/testing
          racket/function
          rackunit
-         web-server/dispatch)
+         web-server/dispatch
+         web-server/dispatchers/dispatch)
 
 (provide
  dispatch-tests)
@@ -60,7 +61,23 @@
 
       (check-equal? (reverse-uri 'home-page) "/")
       (check-equal? (reverse-uri 'order-page 1) "/orders/1")
-      (check-equal? (reverse-uri 'edit-order-page 1) "/admin/orders/1")))))
+      (check-equal? (reverse-uri 'edit-order-page 1) "/admin/orders/1"))
+
+    (test-case "calls `next-dispatcher` if no rule matches"
+      (define-values (dispatch _ __)
+        (dispatch-rules+roles
+         [("")
+          home-page]
+
+         [("orders" (integer-arg))
+          (order-page 'order-manager)]))
+
+      (check-not-exn
+       (lambda () (dispatch (make-test-request #:path "/orders/1"))))
+
+      (check-exn
+       exn:dispatcher?
+       (lambda () (dispatch (make-test-request #:path "/invalid"))))))))
 
 
 (module+ test


### PR DESCRIPTION
The `dispatch-rules+roles` syntax is supposed to call `next-dispacher`
if no rule matches. However, it'll try to call `(next-dispatcher req)`,
failing `next-dispatcher`'s contract:
```
Exception

The application raised an exception with the message:

next-dispatcher: arity mismatch;
 the expected number of arguments does not match the given number
  expected: 0
  given: 1
  arguments...:
   (request #"GET" (url #f #f #f #f #t (list (path/param "invalid" '())) '() #f) (list (header #"Host" #"local") (header #"X-Forwarded-For" #"127.0.0.1") (header #"X-Real-IP" #"127.0.0.1") (header #"user-agent" #"Mozilla/5.0 (Macintosh; Intel Mac...
```