### PR TITLE
url: Allow passing `#:query` to `reverse-uri`.

### DIFF
--- a/koyo-doc/scribblings/dispatch.scrbl
+++ b/koyo-doc/scribblings/dispatch.scrbl
@@ -47,7 +47,7 @@ function.
   @racket[request], can return the required set of roles for the
   matching @racket[dispatch-fun].
 
-  Reverse URI generation is different from @racket[dispatch-roles] in
+  Reverse URI generation is different from @racket[dispatch-rules] in
   that the first argument is a symbol representing the name of the
   route rather than the specific @racket[dispatch-fun] that was used.
   This helps avoid deep dependency chains between routes.  The name

--- a/koyo-doc/scribblings/url.scrbl
+++ b/koyo-doc/scribblings/url.scrbl
@@ -44,7 +44,8 @@ application.
   The default implementation raises an error.
 }
 
-@defproc[(reverse-uri [route symbol?]
+@defproc[(reverse-uri [where symbol?]
+                      [#:query query (listof (cons/c symbol? (or/c false/ string?))) null]
                       [arg any/c] ...) string?]{
 
   Applies the @racket[current-reverse-uri-fn] to @racket[route] and

--- a/koyo-lib/koyo/url.rkt
+++ b/koyo-lib/koyo/url.rkt
@@ -67,13 +67,13 @@
   (make-parameter (lambda (name . args)
                     (error "current-reverse-uri-fn not installed"))))
 
-(define/contract (reverse-uri #:query [params null] . args)
-  (->* ()
+(define/contract (reverse-uri where #:query [params null] . args)
+  (->* (symbol?)
        (#:query (listof (cons/c symbol? (or/c false/c string?))))
        #:rest any/c
        string?)
 
-  (define uri (apply (current-reverse-uri-fn) args))
+  (define uri (apply (current-reverse-uri-fn) where args))
   (cond
     [(null? params) uri]
     [else (format "~a?~a" uri (alist->form-urlencoded params))]))

--- a/koyo-lib/koyo/url.rkt
+++ b/koyo-lib/koyo/url.rkt
@@ -67,7 +67,7 @@
   (make-parameter (lambda (name . args)
                     (error "current-reverse-uri-fn not installed"))))
 
-(define/contract (reverse-uri where #:query [params null] . args)
+(define/contract (reverse-uri where #:query [query null] . args)
   (->* (symbol?)
        (#:query (listof (cons/c symbol? (or/c false/c string?))))
        #:rest any/c
@@ -75,5 +75,5 @@
 
   (define uri (apply (current-reverse-uri-fn) where args))
   (cond
-    [(null? params) uri]
-    [else (format "~a?~a" uri (alist->form-urlencoded params))]))
+    [(null? query) uri]
+    [else (format "~a?~a" uri (alist->form-urlencoded query))]))

--- a/koyo-lib/koyo/url.rkt
+++ b/koyo-lib/koyo/url.rkt
@@ -69,9 +69,10 @@
 
 (define/contract (reverse-uri #:query [params null] . args)
   (->* ()
-       (#:params (listof (cons symbol? (or/c false/c string?))))
+       (#:query (listof (cons/c symbol? (or/c false/c string?))))
        #:rest any/c
        string?)
+
   (define uri (apply (current-reverse-uri-fn) args))
   (cond
     [(null? params) uri]

--- a/koyo-lib/koyo/url.rkt
+++ b/koyo-lib/koyo/url.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require net/url
+(require net/uri-codec
+         net/url
          racket/contract
          racket/function
          racket/match
@@ -66,5 +67,12 @@
   (make-parameter (lambda (name . args)
                     (error "current-reverse-uri-fn not installed"))))
 
-(define (reverse-uri . args)
-  (apply (current-reverse-uri-fn) args))
+(define/contract (reverse-uri #:query [params null] . args)
+  (->* ()
+       (#:params (listof (cons symbol? (or/c false/c string?))))
+       #:rest any/c
+       string?)
+  (define uri (apply (current-reverse-uri-fn) args))
+  (cond
+    [(null? params) uri]
+    [else (format "~a?~a" uri (alist->form-urlencoded params))]))


### PR DESCRIPTION
Modified `reverse-uri` to allow users to specify `query-params`. It's pretty much "first pass", and I haven't updated the documentation, but let me know if you have a different idea or if you think this isn't something that Koyo needs. :)