### PR TITLE
hasher: drop d-r-p

### DIFF
--- a/koyo-lib/koyo/generator.rkt
+++ b/koyo-lib/koyo/generator.rkt
@@ -58,7 +58,7 @@
 
                              RUN apt-get update -y \
                                && apt-get install -y --no-install-recommends \
-                                    dumb-init libargon2-dev
+                                    dumb-init
 
                              ENV @(config-var 'http-host) "0.0.0.0"
                              COPY --from=build /opt/app/dist /opt/dist

--- a/koyo-lib/koyo/hasher/argon2id.rkt
+++ b/koyo-lib/koyo/hasher/argon2id.rkt
@@ -1,21 +1,14 @@
 #lang racket/base
 
-(require (for-syntax racket/base)
-         component
+(require component
          racket/contract
          racket/place
-         racket/runtime-path
          "argon2id-place.rkt"
          "generic.rkt")
 
 (provide
  make-argon2id-hasher-factory
  argon2id-hasher?)
-
-;; Declare a runtime path s.t. the library will automatically be
-;; distributed in executables.
-(define-runtime-path libargon2-so
-  '(so "libargon2"))
 
 (struct argon2id-hasher (config sema [ch #:mutable] running?)
   #:methods gen:component


### PR DESCRIPTION
Defining a runtime path at this level does cause the `so` to get
included in distributions, but it doesn't alter the way the runtime
searches for libs so `crypto-lib` can't find it.  The proper fix here
is to alter `crypto-lib` as in [1].

[1]: https://github.com/rmculpepper/crypto/pull/14