### PR TITLE
Optionally uncolored logging output

### DIFF
--- a/koyo-doc/scribblings/logging.scrbl
+++ b/koyo-doc/scribblings/logging.scrbl
@@ -15,7 +15,8 @@ This module provides utilities for displaying log messages.
 
 @defproc[(start-logger [#:levels levels (listof (cons/c symbol? log-level/c))]
                        [#:parent parent logger? (current-logger)]
-                       [#:output-port out port? (current-error-port)]) (-> void?)]{
+                       [#:output-port out port? (current-error-port)]
+		       [#:color? color? boolean?]) (-> void?)]{
 
   Starts a background thread that receives logs based on
   @racket[levels] and writes them to @racket[out] using the following
@@ -28,4 +29,11 @@ This module provides utilities for displaying log messages.
   The return value is a function that will stop the background thread
   when called.  Calling the stopper function after the thread has been
   stopped has no effect.
+
+  By default, @racket[#:color] is @racket[#t], in which case
+  the log messages with the levels debug, info, warning, and
+  error are all prepended with a color, helpfully indicating
+  their level of severity. If @racket[color?] is
+  @racket[#f], the output will not be colored.
+
 }

--- a/koyo-lib/koyo/logging.rkt
+++ b/koyo-lib/koyo/logging.rkt
@@ -14,10 +14,12 @@
 
 (define/contract (start-logger #:levels levels
                                #:parent [parent (current-logger)]
-                               #:output-port [out (current-error-port)])
+                               #:output-port [out (current-error-port)]
+                               #:color? [color? #t])
   (->* (#:levels (listof (cons/c symbol? log-level/c)))
        (#:parent logger?
-        #:output-port port?)
+        #:output-port port?
+        #:color? boolean?)
        (-> void?))
 
   (define stopped (make-semaphore))
@@ -43,8 +45,10 @@
            [else      null])
          (write-string (~a level #:align 'right #:width 7))))))
   (define formatted-levels
-    (for/list ([level (in-list '(debug info warning error))])
-      (cons level (format-level level))))
+    (cond [color?
+           (for/list ([level (in-list '(debug info warning error))])
+             (cons level (format-level level)))]
+          [else (list)]))
 
   (define (receive-logs)
     (sync


### PR DESCRIPTION
In many situations, the colored prefix of koyo logging messages is appreciated. But when working with terminals that don't support color, it leads to a bunch of control characters in the terminal. This change makes it possible to suppress colors. By default, colors will be used, as before.